### PR TITLE
Solve Merge Intervals

### DIFF
--- a/leetcode/0056-merge-intervals.go
+++ b/leetcode/0056-merge-intervals.go
@@ -1,0 +1,29 @@
+package leetcode
+
+import (
+	"sort"
+)
+
+func merge(intervals [][]int) [][]int {
+	sort.Sort(Intervals(intervals))
+	merged := make([][]int, 0, len(intervals))
+	current := intervals[0]
+	merged = append(merged, current)
+	for _, interval := range intervals[1:] {
+		if current[1] >= interval[0] {
+			if current[1] < interval[1] {
+				current[1] = interval[1]
+			}
+		} else {
+			current = interval
+			merged = append(merged, current)
+		}
+	}
+	return merged
+}
+
+type Intervals [][]int
+
+func (is Intervals) Len() int           { return len(is) }
+func (is Intervals) Less(i, j int) bool { return is[i][0] < is[j][0] }
+func (is Intervals) Swap(i, j int)      { is[i], is[j] = is[j], is[i] }

--- a/leetcode/0056-merge-intervals_test.go
+++ b/leetcode/0056-merge-intervals_test.go
@@ -1,0 +1,39 @@
+package leetcode
+
+import (
+	"fmt"
+	"reflect"
+	"testing"
+)
+
+func TestMerge(t *testing.T) {
+	testCases := []struct {
+		intervals [][]int
+		want      [][]int
+	}{
+		{
+			[][]int{{1, 3}, {2, 6}, {8, 10}, {15, 18}},
+			[][]int{{1, 6}, {8, 10}, {15, 18}},
+		},
+		{
+			[][]int{{1, 4}, {4, 5}},
+			[][]int{{1, 5}},
+		},
+		{
+			[][]int{{1, 6}, {2, 3}, {2, 4}, {5, 7}, {8, 10}},
+			[][]int{{1, 7}, {8, 10}},
+		},
+		{
+			[][]int{{1, 4}, {0, 4}},
+			[][]int{{0, 4}},
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(fmt.Sprint(tc.intervals), func(t *testing.T) {
+			got := merge(tc.intervals)
+			if !reflect.DeepEqual(got, tc.want) {
+				t.Errorf("Want: %v. Got: %v", tc.want, got)
+			}
+		})
+	}
+}


### PR DESCRIPTION
https://leetcode.com/problems/merge-intervals/

Given an array of `intervals` where `intervals[i] = [starti, endi]`, merge all overlapping intervals, and return _an array of the non-overlapping intervals that cover all the intervals in the input_.