### PR TITLE
Solve Insert Interval

### DIFF
--- a/leetcode/0057-insert-interval.go
+++ b/leetcode/0057-insert-interval.go
@@ -1,0 +1,34 @@
+package leetcode
+
+import "sort"
+
+func insert(intervals [][]int, newInterval []int) [][]int {
+	// intervals are given to be in order for starti, and as none of the intervals overlap--for endi, too
+	// so we can use binary search to find the insertion point
+	start := sort.Search(len(intervals), func(i int) bool { return newInterval[0] < intervals[i][0] })
+	end := sort.Search(len(intervals), func(i int) bool { return newInterval[1] < intervals[i][1] })
+	var newLength int
+	if start == end && (start == 0 || intervals[start-1][1] < newInterval[0]) && (end == len(intervals) || intervals[end][0] > newInterval[1]) {
+		// newInterval doesn't overlap with anything, can't be merged, adding as a new interval
+		intervals = append(intervals, []int{})
+		newLength = len(intervals)
+	} else {
+		// merge the intervals around the insertion point
+		if start > 0 && intervals[start-1][1] >= newInterval[0] {
+			start--
+			newInterval[0] = intervals[start][0]
+		}
+		if end < len(intervals) && intervals[end][0] <= newInterval[1] {
+			newInterval[1] = intervals[end][1]
+			end++
+		}
+		newLength = start + 1 + len(intervals) - end
+	}
+
+	// shift the intervals left (if several intervals were merged) or right (if a new one was added)
+	copy(intervals[start+1:], intervals[end:])
+	intervals[start] = newInterval
+	intervals = intervals[:newLength]
+
+	return intervals
+}

--- a/leetcode/0057-insert-interval_test.go
+++ b/leetcode/0057-insert-interval_test.go
@@ -1,0 +1,69 @@
+package leetcode
+
+import (
+	"fmt"
+	"reflect"
+	"testing"
+)
+
+func TestInsert(t *testing.T) {
+	testCases := []struct {
+		intervals   [][]int
+		newInterval []int
+		want        [][]int
+	}{
+		{
+			[][]int{{1, 3}, {6, 9}},
+			[]int{2, 5},
+			[][]int{{1, 5}, {6, 9}},
+		},
+		{
+			[][]int{{1, 2}, {3, 5}, {6, 7}, {8, 10}, {12, 16}},
+			[]int{4, 8},
+			[][]int{{1, 2}, {3, 10}, {12, 16}},
+		},
+		{
+			[][]int{{2, 3}},
+			[]int{1, 2},
+			[][]int{{1, 3}},
+		},
+		{
+			[][]int{{2, 3}},
+			[]int{3, 4},
+			[][]int{{2, 4}},
+		},
+		{
+			[][]int{{2, 3}},
+			[]int{1, 4},
+			[][]int{{1, 4}},
+		},
+		{
+			[][]int{{1, 4}},
+			[]int{2, 3},
+			[][]int{{1, 4}},
+		},
+		{
+			[][]int{{3, 4}},
+			[]int{1, 2},
+			[][]int{{1, 2}, {3, 4}},
+		},
+		{
+			[][]int{{1, 2}},
+			[]int{3, 4},
+			[][]int{{1, 2}, {3, 4}},
+		},
+		{
+			[][]int{{1, 2}, {5, 6}},
+			[]int{3, 4},
+			[][]int{{1, 2}, {3, 4}, {5, 6}},
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(fmt.Sprintf("%v-%v", tc.intervals, tc.newInterval), func(t *testing.T) {
+			got := insert(tc.intervals, tc.newInterval)
+			if !reflect.DeepEqual(got, tc.want) {
+				t.Errorf("Want: %v. Got: %v", tc.want, got)
+			}
+		})
+	}
+}


### PR DESCRIPTION
https://leetcode.com/problems/insert-interval/

You are given an array of non-overlapping intervals `intervals` where `intervals[i] = [starti, endi]` represent the start and the end of the i<sup>th</sup> interval and `intervals` is sorted in ascending order by `starti`. You are also given an interval `newInterval = [start, end]` that represents the start and end of another interval.

Insert `newInterval` into `intervals` such that `intervals` is still sorted in ascending order by `starti` and intervals still does not have any overlapping intervals (merge overlapping intervals if necessary).

Return `intervals` after the insertion.
